### PR TITLE
Add various (de)serializers for PD types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,13 @@ repository = "https://github.com/ZeroCostGoods/pagersduty"
 documentation = "https://docs.rs/pagersduty"
 license = "MIT OR Apache-2.0"
 description = "Rust Client Library for the PagerDuty v2 API"
+build = "build.rs"
+
+[build-dependencies]
+serde_codegen = "0.8"
+glob = "0.2"
 
 [dependencies]
 hyper = "0.9"
+serde = "0.8"
+serde_json = "0.8"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,31 @@
+extern crate glob;
+extern crate serde_codegen;
+
+use std::env;
+use std::fs;
+use glob::glob;
+use std::path::Path;
+
+fn main() {
+    let out_dir = env::var_os("OUT_DIR").unwrap();
+    let types_dir = Path::new(&out_dir).join("types");
+
+    fs::create_dir_all(&types_dir).unwrap();
+
+    for entry in glob("src/types/*.in.rs").unwrap() {
+        if let Ok(src_filename) = entry {
+            let src = Path::new(&src_filename);
+            let type_ = src
+                .file_name().unwrap()
+                .to_str().unwrap()
+                .split(".")
+                .collect::<Vec<&str>>()[0];
+
+            let dst_filename = format!("{}.rs", type_);
+            let dst = types_dir.join(dst_filename);
+
+            serde_codegen::expand(&src, &dst).unwrap();
+        }
+    }
+
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,6 +1,6 @@
 use hyper;
-use hyper::header::{Headers, Accept, Authorization, qitem};
 use hyper::client::response::{Response};
+use hyper::header::{Headers, Accept, Authorization, qitem};
 use hyper::mime::{Mime};
 
 static PD_API_URL: &'static str = "https://api.pagerduty.com";
@@ -30,7 +30,7 @@ impl Client {
             format!("Token token={}", self.auth_token)
         ));
 
-        return headers
+        headers
     }
 
     fn get_accept_header(&self) -> Accept {
@@ -75,4 +75,3 @@ mod tests {
         );
     }
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,9 @@
 //! This library provides access to the Pagerduty v2 API.
 
 extern crate hyper;
+extern crate serde;
+extern crate serde_json;
 
 pub mod client;
 pub mod errors;
+pub mod types;

--- a/src/types/abilities.rs
+++ b/src/types/abilities.rs
@@ -1,0 +1,47 @@
+pub type Abilities = Vec<String>;
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use serde_json;
+    use std::fs::File;
+    use std::io::Read;
+
+    #[test]
+    fn test_serde() {
+        let mut file = File::open("testdata/types/abilities.json").unwrap();
+        let mut data = String::new();
+        file.read_to_string(&mut data).unwrap();
+
+        // Verify deserialization.
+        let abilities: Abilities = serde_json::from_str(&data).unwrap();
+        let expected: Abilities = vec![
+            "sso".into(),
+            "advanced_reports".into(),
+            "teams".into(),
+            "read_only_users".into(),
+            "team_responders".into(),
+            "service_support_hours".into(),
+            "urgencies".into(),
+            "manage_schedules".into(),
+            "manage_api_keys".into(),
+            "coordinated_responding".into(),
+            "using_alerts_on_any_service".into(),
+            "event_rules".into(),
+            "coordinated_responding_preview".into(),
+            "preview_incident_alert_split".into(),
+            "features_in_use_preventing_downgrade_to".into(),
+            "feature_to_plan_map".into(),
+        ];
+        assert_eq!(abilities, expected);
+
+        // Verify that serialization round-trips.
+        let expected: serde_json::Value = serde_json::from_str(&data).unwrap();
+        let serialized: serde_json::Value = serde_json::from_str(
+            serde_json::to_string(&abilities).unwrap().as_ref()
+        ).unwrap();
+        assert_eq!(serialized, expected)
+    }
+}
+

--- a/src/types/contact_methods.in.rs
+++ b/src/types/contact_methods.in.rs
@@ -1,0 +1,409 @@
+use serde::de::{Deserialize, Deserializer};
+use serde::ser::{Serialize, Serializer};
+
+use super::reference::Reference;
+
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+struct ContactMethodUnion {
+    // All Reference's
+    id: String,
+    summary: String,
+    #[serde(rename="type")]
+    type_: String,
+    #[serde(rename="self")]
+    self_: String,
+    html_url: Option<String>,
+
+    // All Concrete type fields
+    address: Option<String>,
+    label: Option<String>,
+    send_short_email: Option<bool>,
+    send_html_email: Option<bool>,
+    blacklisted: Option<bool>,
+    country_code: Option<u32>,
+    enabled: Option<bool>,
+    created_at: Option<String>,
+    device_type: Option<String>,
+    sounds: Option<Vec<PushContactMethodSound>>,
+}
+
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub struct PushContactMethodSound {
+    /// The sound file name.
+    pub file: String,
+
+    /// The type of sound. Expected values include:
+    /// `alert_high_urgency` and `alert_high_urgency`.
+    #[serde(rename = "type")]
+    pub type_: String,
+}
+
+
+#[derive(Debug, PartialEq)]
+pub enum ContactMethod {
+    ContactMethodReference {
+        reference: Reference,
+    },
+
+    EmailContactMethod{
+        reference: Reference,
+
+        /// The `address` to deliver to: email, phone number, etc.,
+        ///  depending on the type.
+        address: String,
+
+        /// The label (e.g., "Work", "Mobile", etc.).
+        label: String,
+
+        /// Send an abbreviated email message instead of the standard email
+        /// output. Useful for email-to-SMS gateways and email based pagers.
+        send_short_email: bool,
+
+        /// Send HTML e-mails.
+        send_html_email: bool,
+    },
+
+    PhoneContactMethod{
+        reference: Reference,
+
+        /// The `address` to deliver to: email, phone number, etc.,
+        ///  depending on the type.
+        address: String,
+
+        /// The label (e.g., "Work", "Mobile", etc.).
+        label: String,
+
+        /// If true, this phone has been blacklisted by
+        /// PagerDuty and no messages will be sent to it.
+        blacklisted: bool,
+
+        /// The 1-to-3 digit country calling code.
+        country_code: u32,
+    },
+
+    SmsContactMethod{
+        reference: Reference,
+
+        /// The `address` to deliver to: email, phone number, etc.,
+        ///  depending on the type.
+        address: String,
+
+        /// The label (e.g., "Work", "Mobile", etc.).
+        label: String,
+
+        /// If true, this phone has been blacklisted by
+        /// PagerDuty and no messages will be sent to it.
+        blacklisted: bool,
+
+        /// The 1-to-3 digit country calling code.
+        country_code: u32,
+
+        /// If true, this phone is capable of receiving SMS messages.
+        enabled: bool,
+    },
+
+    PushNotificationContactMethod{
+        reference: Reference,
+
+        /// The `address` to deliver to: email, phone number, etc.,
+        ///  depending on the type.
+        address: String,
+
+        /// The label (e.g., "Work", "Mobile", etc.).
+        label: String,
+
+        /// If true, this phone has been blacklisted by PagerDuty and no messages will be sent to it.",
+        blacklisted: bool,
+
+        // TODO(gary): Use date-time field?
+        /// Time at which the contact method was created.
+        created_at: String,
+
+        /// The type of device. Expected values include:
+        /// `ios` and `android`.
+        device_type: String,
+
+        sounds: Vec<PushContactMethodSound>,
+    },
+
+}
+
+
+impl Serialize for ContactMethod {
+    fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
+        where S: Serializer
+    {
+        let mut state = serializer.serialize_map(None)?;
+
+        match *self {
+            ContactMethod::ContactMethodReference{
+                ref reference
+            } => {
+                reference.serialize_key_vals(serializer, &mut state)?;
+            },
+            ContactMethod::EmailContactMethod{
+                ref reference, ref address, ref label,
+                ref send_short_email, ref send_html_email,
+            } => {
+                reference.serialize_key_vals(serializer, &mut state)?;
+
+                serializer.serialize_map_key(&mut state, "address")?;
+                serializer.serialize_map_value(&mut state, address)?;
+
+                serializer.serialize_map_key(&mut state, "label")?;
+                serializer.serialize_map_value(&mut state, label)?;
+
+                serializer.serialize_map_key(&mut state, "send_short_email")?;
+                serializer.serialize_map_value(&mut state, send_short_email)?;
+
+                serializer.serialize_map_key(&mut state, "send_html_email")?;
+                serializer.serialize_map_value(&mut state, send_html_email)?;
+            },
+            ContactMethod::PhoneContactMethod{
+                ref reference, ref address, ref label,
+                ref blacklisted, ref country_code,
+            } => {
+                reference.serialize_key_vals(serializer, &mut state)?;
+
+                serializer.serialize_map_key(&mut state, "address")?;
+                serializer.serialize_map_value(&mut state, address)?;
+
+                serializer.serialize_map_key(&mut state, "label")?;
+                serializer.serialize_map_value(&mut state, label)?;
+
+                serializer.serialize_map_key(&mut state, "country_code")?;
+                serializer.serialize_map_value(&mut state, country_code)?;
+
+                serializer.serialize_map_key(&mut state, "blacklisted")?;
+                serializer.serialize_map_value(&mut state, blacklisted)?;
+
+            },
+            ContactMethod::SmsContactMethod{
+                ref reference, ref address, ref label,
+                ref blacklisted, ref country_code, ref enabled,
+            } => {
+                reference.serialize_key_vals(serializer, &mut state)?;
+
+                serializer.serialize_map_key(&mut state, "address")?;
+                serializer.serialize_map_value(&mut state, address)?;
+
+                serializer.serialize_map_key(&mut state, "label")?;
+                serializer.serialize_map_value(&mut state, label)?;
+
+                serializer.serialize_map_key(&mut state, "country_code")?;
+                serializer.serialize_map_value(&mut state, country_code)?;
+
+                serializer.serialize_map_key(&mut state, "blacklisted")?;
+                serializer.serialize_map_value(&mut state, blacklisted)?;
+
+                serializer.serialize_map_key(&mut state, "enabled")?;
+                serializer.serialize_map_value(&mut state, enabled)?;
+            },
+            ContactMethod::PushNotificationContactMethod{
+                ref reference, ref address, ref label,
+                ref blacklisted, ref created_at, ref device_type,
+                ref sounds,
+            } => {
+                reference.serialize_key_vals(serializer, &mut state)?;
+
+                serializer.serialize_map_key(&mut state, "address")?;
+                serializer.serialize_map_value(&mut state, address)?;
+
+                serializer.serialize_map_key(&mut state, "label")?;
+                serializer.serialize_map_value(&mut state, label)?;
+
+                serializer.serialize_map_key(&mut state, "device_type")?;
+                serializer.serialize_map_value(&mut state, device_type)?;
+
+                serializer.serialize_map_key(&mut state, "sounds")?;
+                serializer.serialize_map_value(&mut state, sounds)?;
+
+                serializer.serialize_map_key(&mut state, "blacklisted")?;
+                serializer.serialize_map_value(&mut state, blacklisted)?;
+
+                serializer.serialize_map_key(&mut state, "created_at")?;
+                serializer.serialize_map_value(&mut state, created_at)?;
+            },
+        }
+
+        serializer.serialize_map_end(state)
+    }
+}
+
+impl Deserialize for ContactMethod {
+    fn deserialize<D>(deserializer: &mut D) -> Result<ContactMethod, D::Error>
+        where D: Deserializer
+    {
+        let union = ContactMethodUnion::deserialize(deserializer)?;
+
+        let reference = Reference {
+            id: union.id,
+            summary: union.summary,
+            type_: union.type_,
+            self_: union.self_,
+            html_url: union.html_url,
+        };
+
+        match reference.type_.as_ref() {
+            "contact_method_reference" |
+            "email_contact_method_reference" |
+            "phone_contact_method_reference" |
+            "sms_contact_method_reference" |
+            "push_notification_contact_method_reference"
+            => {
+                Ok(ContactMethod::ContactMethodReference {
+                    reference: reference,
+                })
+            },
+            "email_contact_method" => {
+                Ok(ContactMethod::EmailContactMethod {
+                    reference: reference,
+                    address: union.address.expect("address"),
+                    label: union.label.expect("label"),
+                    send_short_email: union.send_short_email.expect("send_short_email"),
+                    send_html_email: union.send_html_email.expect("send_html_email"),
+                })
+            },
+            "phone_contact_method" => {
+                Ok(ContactMethod::PhoneContactMethod {
+                    reference: reference,
+                    address: union.address.expect("address"),
+                    label: union.label.expect("label"),
+                    blacklisted: union.blacklisted.expect("blacklisted"),
+                    country_code: union.country_code.expect("country_code"),
+                })
+            },
+            "sms_contact_method" => {
+                Ok(ContactMethod::SmsContactMethod {
+                    reference: reference,
+                    address: union.address.expect("address"),
+                    label: union.label.expect("label"),
+                    blacklisted: union.blacklisted.expect("blacklisted"),
+                    country_code: union.country_code.expect("country_code"),
+                    enabled: union.enabled.expect("enabled"),
+                })
+            },
+            "push_notification_contact_method" => {
+                Ok(ContactMethod::PushNotificationContactMethod {
+                    reference: reference,
+                    address: union.address.expect("address"),
+                    label: union.label.expect("label"),
+                    blacklisted: union.blacklisted.expect("blacklisted"),
+                    created_at: union.created_at.expect("created_at"),
+                    device_type: union.device_type.expect("device_type"),
+                    sounds: union.sounds.expect("sounds"),
+                })
+            },
+            _ => panic!("fuuuuuuu"),
+        }
+    }
+}
+
+
+pub type ContactMethods = Vec<ContactMethod>;
+
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use serde_json;
+    use std::fs::File;
+    use std::io::Read;
+    use super::super::reference::Reference;
+
+    #[test]
+    fn test_serde() {
+        let mut file = File::open("testdata/types/contact_methods.json").unwrap();
+        let mut data = String::new();
+        file.read_to_string(&mut data).unwrap();
+        let contact_methods: ContactMethods = serde_json::from_str(&data).unwrap();
+
+        // Verify deserialization.
+        assert_eq!(
+            contact_methods,
+            vec![
+
+                ContactMethod::ContactMethodReference {
+                    reference: Reference {
+                        id: "PPPIOPG".into(),
+                        summary: "Default".into(),
+                        type_: "email_contact_method_reference".into(),
+                        self_: "https://api.pagerduty.com/users/PZ7JFQ7/contact_methods/PPPIOPG".into(),
+                        html_url: None,
+                    },
+                },
+                ContactMethod::EmailContactMethod {
+                    reference: Reference {
+                        id: "P33R0ZA".into(),
+                        summary: "Work".into(),
+                        type_: "email_contact_method".into(),
+                        self_: "https://api.pagerduty.com/users/PZ7JFQ7/contact_methods/P33R0ZA".into(),
+                        html_url: None,
+                    },
+                    address: "alejandro@example.com".into(),
+                    label: "Work".into(),
+                    send_short_email: false,
+                    send_html_email: false,
+                },
+                ContactMethod::SmsContactMethod {
+                    reference: Reference {
+                        id: "PEC83HY".into(),
+                        summary: "Mobile".into(),
+                        type_: "sms_contact_method".into(),
+                        self_: "https://api.pagerduty.com/users/PGJ36Z3/contact_methods/PEC83HY".into(),
+                        html_url: None,
+                    },
+                    address: "4155809923".into(),
+                    label: "Mobile".into(),
+                    blacklisted: false,
+                    country_code: 1,
+                    enabled: true,
+                },
+                ContactMethod::PhoneContactMethod {
+                    reference: Reference {
+                        id: "PBUSVMD".into(),
+                        summary: "Mobile".into(),
+                        type_: "phone_contact_method".into(),
+                        self_: "https://api.pagerduty.com/users/P1RQ0Z6/contact_methods/PBUSVMD".into(),
+                        html_url: None,
+                    },
+                    address: "7076949626".into(),
+                    label: "Mobile".into(),
+                    blacklisted: false,
+                    country_code: 1,
+                },
+                ContactMethod::PushNotificationContactMethod {
+                    reference: Reference {
+                        id: "P4G3JKD".into(),
+                        summary: "Alex\'s iPhone".into(),
+                        type_: "push_notification_contact_method".into(),
+                        self_: "https://api.pagerduty.com/users/P1RQ0Z6/contact_methods/P4G3JKD".into(),
+                        html_url: None,
+                    },
+                    address: "fcbaba06abe7533794b0dd7c3f4427b574772c01445e06bb5a006c33f14d95d0".into(),
+                    label: "Alex\'s iPhone".into(),
+                    blacklisted: false,
+                    created_at: "2016-07-11T11:36:41-07:00".into(),
+                    device_type: "ios".into(),
+                    sounds: vec![
+                        PushContactMethodSound {
+                            file: "default".into(),
+                            type_: "alert_high_urgency".into(),
+                        }
+                    ],
+                }
+            ]
+        );
+
+        // Verify that serialization round-trips.
+        let expected: serde_json::Value = serde_json::from_str(&data).unwrap();
+        let serialized: serde_json::Value = serde_json::from_str(
+            serde_json::to_string(&contact_methods).unwrap().as_ref()
+        ).unwrap();
+        assert_eq!(serialized, expected)
+    }
+}
+

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,0 +1,8 @@
+pub mod reference;
+pub mod abilities;
+
+// Modules that use serde-codegen
+pub mod contact_methods { include!(concat!(env!("OUT_DIR"), "/types/contact_methods.rs")); }
+pub mod notification_rules { include!(concat!(env!("OUT_DIR"), "/types/notification_rules.rs")); }
+pub mod teams { include!(concat!(env!("OUT_DIR"), "/types/teams.rs")); }
+pub mod users { include!(concat!(env!("OUT_DIR"), "/types/users.rs")); }

--- a/src/types/notification_rules.in.rs
+++ b/src/types/notification_rules.in.rs
@@ -1,0 +1,242 @@
+use serde::de::{Deserialize, Deserializer};
+use serde::ser::{Serialize, Serializer};
+
+use super::reference::Reference;
+use super::contact_methods::ContactMethod;
+
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+struct NotificationRuleUnion {
+    // All Reference's
+    id: String,
+    summary: String,
+    #[serde(rename="type")]
+    type_: String,
+    #[serde(rename="self")]
+    self_: String,
+    html_url: Option<String>,
+
+    // All Concrete type fields
+    start_delay_in_minutes: Option<u32>,
+    contact_method: Option<ContactMethod>,
+    urgency: Option<String>,
+}
+
+
+#[derive(Debug, PartialEq)]
+pub enum NotificationRule {
+    NotificationRuleReference {
+        reference: Reference,
+    },
+
+    NotificationRule {
+        reference: Reference,
+
+        /// The delay before firing the rule, in minutes.
+        start_delay_in_minutes: u32,
+
+        /// The contact method invoked by the rule.
+        contact_method: ContactMethod,
+
+        /// Which incident urgency this rule is used for. Account must have the
+        ///  `urgencies` ability to have a low urgency notification rule.
+        /// Expected values include: `high` and `low`.
+        urgency: String,
+    },
+}
+
+
+impl Serialize for NotificationRule {
+    fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
+        where S: Serializer
+    {
+        let mut state = serializer.serialize_map(None)?;
+
+        match *self {
+            NotificationRule::NotificationRuleReference{
+                ref reference
+            } => {
+                reference.serialize_key_vals(serializer, &mut state)?;
+            },
+            NotificationRule::NotificationRule{
+                ref reference, ref start_delay_in_minutes,
+                ref contact_method, ref urgency,
+            } => {
+                reference.serialize_key_vals(serializer, &mut state)?;
+
+                serializer.serialize_map_key(&mut state, "start_delay_in_minutes")?;
+                serializer.serialize_map_value(&mut state, start_delay_in_minutes)?;
+
+                serializer.serialize_map_key(&mut state, "contact_method")?;
+                serializer.serialize_map_value(&mut state, contact_method)?;
+
+                serializer.serialize_map_key(&mut state, "urgency")?;
+                serializer.serialize_map_value(&mut state, urgency)?;
+            },
+        }
+
+        serializer.serialize_map_end(state)
+    }
+}
+
+impl Deserialize for NotificationRule {
+    fn deserialize<D>(deserializer: &mut D) -> Result<NotificationRule, D::Error>
+        where D: Deserializer
+    {
+        let union = NotificationRuleUnion::deserialize(deserializer)?;
+
+        let reference = Reference {
+            id: union.id,
+            summary: union.summary,
+            type_: union.type_,
+            self_: union.self_,
+            html_url: union.html_url,
+        };
+
+        match reference.type_.as_ref() {
+            "assignment_notification_rule_reference"  => {
+                Ok(NotificationRule::NotificationRuleReference {
+                    reference: reference,
+                })
+            },
+            "assignment_notification_rule" => {
+                Ok(NotificationRule::NotificationRule {
+                    reference: reference,
+                    start_delay_in_minutes: union.start_delay_in_minutes.expect("start_delay_in_minutes"),
+                    contact_method: union.contact_method.expect("contact_method"),
+                    urgency: union.urgency.expect("urgency"),
+                })
+            },
+            _ => panic!("fuuuuuuu"),
+        }
+    }
+}
+
+
+pub type NotificationRules = Vec<NotificationRule>;
+
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use serde_json;
+    use std::fs::File;
+    use std::io::Read;
+    use super::super::reference::Reference;
+    use super::super::contact_methods::ContactMethod;
+
+    #[test]
+    fn test_serde() {
+        let mut file = File::open("testdata/types/notification_rules.json").unwrap();
+        let mut data = String::new();
+        file.read_to_string(&mut data).unwrap();
+        let notification_rules: NotificationRules = serde_json::from_str(&data).unwrap();
+
+        // Verify deserialization.
+        assert_eq!(
+            notification_rules,
+            vec![
+                NotificationRule::NotificationRuleReference {
+                    reference: Reference {
+                        id: "PM41X3T".into(),
+                        summary: "0 minutes: channel P6YMJEE".into(),
+                        type_: "assignment_notification_rule_reference".into(),
+                        self_: "https://api.pagerduty.com/users/P5T36BU/notification_rules/PM41X3T".into(),
+                        html_url: None,
+                    },
+                },
+                NotificationRule::NotificationRuleReference {
+                    reference: Reference {
+                        id: "PNTRY7M".into(),
+                        summary: "0 minutes: channel P6YMJEE".into(),
+                        type_: "assignment_notification_rule_reference".into(),
+                        self_: "https://api.pagerduty.com/users/P5T36BU/notification_rules/PNTRY7M".into(),
+                        html_url: None,
+                    },
+                },
+                NotificationRule::NotificationRule {
+                    reference: Reference {
+                        id: "PW0WSB8".into(),
+                        summary: "0 minutes: channel PX11CYC".into(),
+                        type_: "assignment_notification_rule".into(),
+                        self_: "https://api.pagerduty.com/users/PGJ36Z3/notification_rules/PW0WSB8".into(),
+                        html_url: None,
+                    },
+                    start_delay_in_minutes: 0,
+                    contact_method: ContactMethod::EmailContactMethod {
+                        reference: Reference {
+                            id: "PX11CYC".into(),
+                            summary: "Default".into(),
+                            type_: "email_contact_method".into(),
+                            self_: "https://api.pagerduty.com/users/PGJ36Z3/contact_methods/PX11CYC".into(),
+                            html_url: None,
+                        },
+                        address: "acunningham@pagerduty.com".into(),
+                        label: "Default".into(),
+                        send_short_email: false,
+                        send_html_email: false,
+                    },
+                    urgency: "high".into(),
+                },
+                NotificationRule::NotificationRule {
+                    reference: Reference {
+                        id: "PGITUFO".into(),
+                        summary: "0 minutes: channel PX11CYC".into(),
+                        type_: "assignment_notification_rule".into(),
+                        self_: "https://api.pagerduty.com/users/PGJ36Z3/notification_rules/PGITUFO".into(),
+                        html_url: None,
+                    },
+                    start_delay_in_minutes: 0,
+                    contact_method: ContactMethod::EmailContactMethod {
+                        reference: Reference {
+                            id: "PX11CYC".into(),
+                            summary: "Default".into(),
+                            type_: "email_contact_method".into(),
+                            self_: "https://api.pagerduty.com/users/PGJ36Z3/contact_methods/PX11CYC".into(),
+                            html_url: None,
+                        },
+                        address: "acunningham@pagerduty.com".into(),
+                        label: "Default".into(),
+                        send_short_email: false,
+                        send_html_email: false,
+                    },
+                    urgency: "low".into(),
+                },
+                NotificationRule::NotificationRule {
+                    reference: Reference {
+                        id: "PEY06R9".into(),
+                        summary: "0 minutes: channel PEC83HY".into(),
+                        type_: "assignment_notification_rule".into(),
+                        self_: "https://api.pagerduty.com/users/PGJ36Z3/notification_rules/PEY06R9".into(),
+                        html_url: None,
+                    },
+                    start_delay_in_minutes: 0,
+                    contact_method: ContactMethod::SmsContactMethod {
+                        reference: Reference {
+                            id: "PEC83HY".into(),
+                            summary: "Mobile".into(),
+                            type_: "sms_contact_method".into(),
+                            self_: "https://api.pagerduty.com/users/PGJ36Z3/contact_methods/PEC83HY".into(),
+                            html_url: None,
+                        },
+                        address: "4155809923".into(),
+                        label: "Mobile".into(),
+                        blacklisted: false,
+                        country_code: 1,
+                        enabled: true,
+                    },
+                    urgency: "high".into(),
+                },
+            ]
+        );
+
+        // Verify that serialization round-trips.
+        let expected: serde_json::Value = serde_json::from_str(&data).unwrap();
+        let serialized: serde_json::Value = serde_json::from_str(
+            serde_json::to_string(&notification_rules).unwrap().as_ref()
+        ).unwrap();
+        assert_eq!(serialized, expected)
+    }
+}
+

--- a/src/types/reference.rs
+++ b/src/types/reference.rs
@@ -1,0 +1,57 @@
+//! Many of the types you receive back from the PagerDuty API contain references
+//! to other types. Most types, whether a reference or not, contain the same fields
+//! consisently. Rather than duplicate those fields on each type we compose the
+//! `Reference` type in other types. This type is not something you'd normally
+//! access directly, but through another type.
+//!
+//! You can read more about references here:
+//! https://v2.developer.pagerduty.com/v2/docs/references
+
+
+use serde::ser::Serializer;
+
+
+#[derive(Debug, PartialEq)]
+pub struct Reference {
+    pub id: String,
+
+    /// A short-form, server-generated string that provides succinct,
+    /// important information about an object suitable for primary
+    /// labeling of an entity in a client. In many cases, this will be
+    /// identical to `name`, though it is not intended to be an identifier.
+    pub summary: String,
+
+    /// The type of contact method.
+    pub type_: String,
+
+    /// The API show URL at which the object is accessible.
+    pub self_: String,
+
+    /// A URL at which the entity is uniquely displayed in the Web app.
+    pub html_url: Option<String>,
+}
+
+
+impl Reference {
+    pub fn serialize_key_vals<S>(&self, serializer: &mut S, mut state: &mut S::MapState) -> Result<(), S::Error>
+        where S: Serializer
+    {
+        serializer.serialize_map_key(&mut state, "id")?;
+        serializer.serialize_map_value(&mut state, &self.id)?;
+
+        serializer.serialize_map_key(&mut state, "summary")?;
+        serializer.serialize_map_value(&mut state, &self.summary)?;
+
+        serializer.serialize_map_key(&mut state, "type")?;
+        serializer.serialize_map_value(&mut state, &self.type_)?;
+
+        serializer.serialize_map_key(&mut state, "self")?;
+        serializer.serialize_map_value(&mut state, &self.self_)?;
+
+        serializer.serialize_map_key(&mut state, "html_url")?;
+        serializer.serialize_map_value(&mut state, &self.html_url)?;
+
+        Ok(())
+    }
+}
+

--- a/src/types/teams.in.rs
+++ b/src/types/teams.in.rs
@@ -1,0 +1,162 @@
+use serde::de::{Deserialize, Deserializer};
+use serde::ser::{Serialize, Serializer};
+
+use super::reference::Reference;
+
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+struct TeamUnion {
+    // All Reference's
+    id: String,
+    summary: String,
+    #[serde(rename="type")]
+    type_: String,
+    #[serde(rename="self")]
+    self_: String,
+    html_url: Option<String>,
+
+    // All Concrete type fields
+    name: Option<String>,
+    description: Option<String>,
+}
+
+
+#[derive(Debug, PartialEq)]
+pub enum Team {
+    TeamReference {
+        reference: Reference,
+    },
+
+    Team {
+        reference: Reference,
+
+        /// The name of the team.
+        name: String,
+
+        /// The description of the team.
+        description: Option<String>,
+    },
+}
+
+
+impl Serialize for Team {
+    fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
+        where S: Serializer
+    {
+        let mut state = serializer.serialize_map(None)?;
+
+        match *self {
+            Team::TeamReference{
+                ref reference
+            } => {
+                reference.serialize_key_vals(serializer, &mut state)?;
+            },
+            Team::Team{
+                ref reference, ref name, ref description
+            } => {
+                reference.serialize_key_vals(serializer, &mut state)?;
+
+                serializer.serialize_map_key(&mut state, "name")?;
+                serializer.serialize_map_value(&mut state, name)?;
+
+                serializer.serialize_map_key(&mut state, "description")?;
+                serializer.serialize_map_value(&mut state, description)?;
+            },
+        }
+
+        serializer.serialize_map_end(state)
+    }
+}
+
+impl Deserialize for Team {
+    fn deserialize<D>(deserializer: &mut D) -> Result<Team, D::Error>
+        where D: Deserializer
+    {
+        let union = TeamUnion::deserialize(deserializer)?;
+
+        let reference = Reference {
+            id: union.id,
+            summary: union.summary,
+            type_: union.type_,
+            self_: union.self_,
+            html_url: union.html_url,
+        };
+
+        match reference.type_.as_ref() {
+            "team_reference"  => {
+                Ok(Team::TeamReference {
+                    reference: reference,
+                })
+            },
+            "team" => {
+                Ok(Team::Team {
+                    reference: reference,
+                    name: union.name.expect("name"),
+                    description: union.description,
+                })
+            },
+            _ => panic!("fuuuuuuu"),
+        }
+    }
+}
+
+
+pub type Teams = Vec<Team>;
+
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use serde_json;
+    use std::fs::File;
+    use std::io::Read;
+    use super::super::reference::Reference;
+
+    #[test]
+    fn test_serde() {
+        let mut file = File::open("testdata/types/teams.json").unwrap();
+        let mut data = String::new();
+        file.read_to_string(&mut data).unwrap();
+        let teams: Teams = serde_json::from_str(&data).unwrap();
+
+        // Verify deserialization.
+        assert_eq!(
+            teams,
+            vec![
+                Team::TeamReference {
+                    reference: Reference {
+                        id: "PRJ4D5C".into(),
+                        summary: "ops".into(),
+                        type_: "team_reference".into(),
+                        self_: "https://api.pagerduty.com/teams/PRJ4D5C".into(),
+                        html_url: Some(
+                            "https://webdemo.pagerduty.com/teams/PRJ4D5C".into()
+                        ),
+                    },
+                },
+                Team::Team {
+                    reference: Reference {
+                        id: "P7W0ZIU".into(),
+                        summary: "Monitoring Tools Team".into(),
+                        type_: "team".into(),
+                        self_: "https://api.pagerduty.com/teams/P7W0ZIU".into(),
+                        html_url: Some(
+                            "https://webdemo.pagerduty.com/teams/P7W0ZIU".into()
+                        ),
+                    },
+                    name: "Monitoring Tools Team".into(),
+                    description: None,
+                },
+            ]
+        );
+
+        // Verify that serialization round-trips.
+        let expected: serde_json::Value = serde_json::from_str(&data).unwrap();
+        let serialized: serde_json::Value = serde_json::from_str(
+            serde_json::to_string(&teams).unwrap().as_ref()
+        ).unwrap();
+        assert_eq!(serialized, expected)
+    }
+}
+

--- a/src/types/users.in.rs
+++ b/src/types/users.in.rs
@@ -1,0 +1,296 @@
+use serde::de::{Deserialize, Deserializer};
+use serde::ser::{Serialize, Serializer};
+
+use super::reference::Reference;
+use super::contact_methods::ContactMethods;
+use super::notification_rules::NotificationRules;
+use super::teams::Teams;
+
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+struct UserUnion {
+    // All Reference's
+    id: String,
+    summary: String,
+    #[serde(rename="type")]
+    type_: String,
+    #[serde(rename="self")]
+    self_: String,
+    html_url: Option<String>,
+
+    // All Concrete type fields
+    avatar_url: Option<String>,
+    color: Option<String>,
+    contact_methods: Option<ContactMethods>,
+    description: Option<String>,
+    email: Option<String>,
+    invitation_sent: Option<bool>,
+    job_title: Option<String>,
+    name: Option<String>,
+    notification_rules: Option<NotificationRules>,
+    role: Option<String>,
+    teams: Option<Teams>,
+    time_zone: Option<String>,
+}
+
+
+#[derive(Debug, PartialEq)]
+pub enum User {
+    UserReference {
+        reference: Reference,
+    },
+
+    User {
+        reference: Reference,
+
+        /// The URL of the user's avatar.
+        avatar_url: String,
+
+        /// The schedule color.
+        color: String,
+
+        /// The list of contact methods for the user.
+        contact_methods: ContactMethods,
+
+        /// The user's bio
+        description: Option<String>,
+
+        /// The user's email address.
+        email: String,
+
+        /// If true, the user has an outstanding invitation.
+        invitation_sent: bool,
+
+        /// The user's title.
+        job_title: Option<String>,
+
+        /// The name of the user.
+        name: String,
+
+        /// The list of notification rules for the user.
+        notification_rules: NotificationRules,
+
+        /// The user role. Account must have the `read_only_users`
+        /// ability to set a user as a `read_only_user`.
+        ///
+        /// Expected values include:
+        /// `admin`, `limited_user`, `owner`, `read_only_user`, and `user`
+        role: String,
+
+        /// The list of teams to which the user belongs. Account must
+        /// have the `teams` ability to set this.
+        teams: Teams,
+
+        /// The preferred time zone name. If null, the account's time
+        /// zone will be used.
+        time_zone: String,
+
+    },
+}
+
+
+impl Serialize for User {
+    fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
+        where S: Serializer
+    {
+        let mut state = serializer.serialize_map(None)?;
+
+        match *self {
+            User::UserReference{
+                ref reference
+            } => {
+                reference.serialize_key_vals(serializer, &mut state)?;
+            },
+            User::User{
+                ref reference,
+                ref avatar_url, ref color,  ref contact_methods, ref description,
+                ref email, ref invitation_sent, ref job_title, ref name,
+                ref notification_rules, ref role, ref teams, ref time_zone,
+            } => {
+                reference.serialize_key_vals(serializer, &mut state)?;
+
+                serializer.serialize_map_key(&mut state, "avatar_url")?;
+                serializer.serialize_map_value(&mut state, avatar_url)?;
+
+                serializer.serialize_map_key(&mut state, "color")?;
+                serializer.serialize_map_value(&mut state, color)?;
+
+                serializer.serialize_map_key(&mut state, "contact_methods")?;
+                serializer.serialize_map_value(&mut state, contact_methods)?;
+
+                serializer.serialize_map_key(&mut state, "description")?;
+                serializer.serialize_map_value(&mut state, description)?;
+
+                serializer.serialize_map_key(&mut state, "email")?;
+                serializer.serialize_map_value(&mut state, email)?;
+
+                serializer.serialize_map_key(&mut state, "invitation_sent")?;
+                serializer.serialize_map_value(&mut state, invitation_sent)?;
+
+                serializer.serialize_map_key(&mut state, "job_title")?;
+                serializer.serialize_map_value(&mut state, job_title)?;
+
+                serializer.serialize_map_key(&mut state, "name")?;
+                serializer.serialize_map_value(&mut state, name)?;
+
+                serializer.serialize_map_key(&mut state, "notification_rules")?;
+                serializer.serialize_map_value(&mut state, notification_rules)?;
+
+                serializer.serialize_map_key(&mut state, "role")?;
+                serializer.serialize_map_value(&mut state, role)?;
+
+                serializer.serialize_map_key(&mut state, "teams")?;
+                serializer.serialize_map_value(&mut state, teams)?;
+
+                serializer.serialize_map_key(&mut state, "time_zone")?;
+                serializer.serialize_map_value(&mut state, time_zone)?;
+            },
+        }
+
+        serializer.serialize_map_end(state)
+    }
+}
+
+impl Deserialize for User {
+    fn deserialize<D>(deserializer: &mut D) -> Result<User, D::Error>
+        where D: Deserializer
+    {
+        let union = UserUnion::deserialize(deserializer)?;
+
+        let reference = Reference {
+            id: union.id,
+            summary: union.summary,
+            type_: union.type_,
+            self_: union.self_,
+            html_url: union.html_url,
+        };
+
+        match reference.type_.as_ref() {
+            "user_reference"  => {
+                Ok(User::UserReference {
+                    reference: reference,
+                })
+            },
+            "user" => {
+                Ok(User::User {
+                    reference: reference,
+                    avatar_url: union.avatar_url.expect("avatar_url"),
+                    color: union.color.expect("color"),
+                    contact_methods: union.contact_methods.expect("contact_methods"),
+                    description: union.description,
+                    email: union.email.expect("email"),
+                    invitation_sent: union.invitation_sent.expect("invitation_sent"),
+                    job_title: union.job_title,
+                    name: union.name.expect("name"),
+                    notification_rules: union.notification_rules.expect("notification_rules"),
+                    role: union.role.expect("role"),
+                    teams: union.teams.expect("teams"),
+                    time_zone: union.time_zone.expect("time_zone"),
+                })
+            },
+            _ => panic!("fuuuuuuu"),
+        }
+    }
+}
+
+
+pub type Users = Vec<User>;
+
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use serde_json;
+    use std::fs::File;
+    use std::io::Read;
+    use super::super::reference::Reference;
+    use super::super::contact_methods::ContactMethod;
+    use super::super::notification_rules::NotificationRule;
+
+    #[test]
+    fn test_serde() {
+        let mut file = File::open("testdata/types/users.json").unwrap();
+        let mut data = String::new();
+        file.read_to_string(&mut data).unwrap();
+        let users: Users = serde_json::from_str(&data).unwrap();
+
+        // Verify deserialization.
+        assert_eq!(
+            users,
+            vec![
+                User::UserReference {
+                    reference: Reference {
+                        id: "PRMXSSO".into(),
+                        summary: "Benedict Cumberbatch".into(),
+                        type_: "user_reference".into(),
+                        self_: "https://api.pagerduty.com/users/PRMXSSO".into(),
+                        html_url: Some(
+                            "https://webdemo.pagerduty.com/users/PRMXSSO".into()
+                        ),
+                    },
+                },
+                User::User {
+                    reference: Reference {
+                        id: "P5T36BU".into(),
+                        summary: "abhijit@pagerduty.com".into(),
+                        type_: "user".into(),
+                        self_: "https://api.pagerduty.com/users/P5T36BU".into(),
+                        html_url: Some(
+                            "https://webdemo.pagerduty.com/users/P5T36BU".into()
+                        ),
+                    },
+                    avatar_url: "https://secure.gravatar.com/avatar/267299c8432bf9ab044472009c89a674.png?d=mm&r=PG".into(),
+                    color: "olivedrab".into(),
+                    contact_methods: vec![
+                        ContactMethod::ContactMethodReference {
+                            reference: Reference {
+                                id: "P6YMJEE".into(),
+                                summary: "Default".into(),
+                                type_: "email_contact_method_reference".into(),
+                                self_: "https://api.pagerduty.com/users/P5T36BU/contact_methods/P6YMJEE".into(),
+                                html_url: None,
+                            },
+                        },
+                    ],
+                    description: None,
+                    email: "abhijit@pagerduty.com".into(),
+                    invitation_sent: false,
+                    job_title: None,
+                    name: "abhijit@pagerduty.com".into(),
+                    notification_rules: vec![
+                        NotificationRule::NotificationRuleReference {
+                            reference: Reference {
+                                id: "PM41X3T".into(),
+                                summary: "0 minutes: channel P6YMJEE".into(),
+                                type_: "assignment_notification_rule_reference".into(),
+                                self_: "https://api.pagerduty.com/users/P5T36BU/notification_rules/PM41X3T".into(),
+                                html_url: None,
+                            },
+                        },
+                        NotificationRule::NotificationRuleReference {
+                            reference: Reference {
+                                id: "PNTRY7M".into(),
+                                summary: "0 minutes: channel P6YMJEE".into(),
+                                type_: "assignment_notification_rule_reference".into(),
+                                self_: "https://api.pagerduty.com/users/P5T36BU/notification_rules/PNTRY7M".into(),
+                                html_url: None,
+                            },
+                        },
+                    ],
+                    role: "user".into(),
+                    teams: vec![],
+                    time_zone: "America/Los_Angeles".into(),
+                },
+            ]
+        );
+
+        // Verify that serialization round-trips.
+        let expected: serde_json::Value = serde_json::from_str(&data).unwrap();
+        let serialized: serde_json::Value = serde_json::from_str(
+            serde_json::to_string(&users).unwrap().as_ref()
+        ).unwrap();
+        assert_eq!(serialized, expected)
+    }
+}
+

--- a/testdata/types/abilities.json
+++ b/testdata/types/abilities.json
@@ -1,0 +1,18 @@
+[
+  "sso",
+  "advanced_reports",
+  "teams",
+  "read_only_users",
+  "team_responders",
+  "service_support_hours",
+  "urgencies",
+  "manage_schedules",
+  "manage_api_keys",
+  "coordinated_responding",
+  "using_alerts_on_any_service",
+  "event_rules",
+  "coordinated_responding_preview",
+  "preview_incident_alert_split",
+  "features_in_use_preventing_downgrade_to",
+  "feature_to_plan_map"
+]

--- a/testdata/types/contact_methods.json
+++ b/testdata/types/contact_methods.json
@@ -1,0 +1,61 @@
+[
+  {
+    "id": "PPPIOPG",
+    "type": "email_contact_method_reference",
+    "summary": "Default",
+    "self": "https://api.pagerduty.com/users/PZ7JFQ7/contact_methods/PPPIOPG",
+    "html_url": null
+  },
+  {
+    "id": "P33R0ZA",
+    "type": "email_contact_method",
+    "summary": "Work",
+    "self": "https://api.pagerduty.com/users/PZ7JFQ7/contact_methods/P33R0ZA",
+    "html_url": null,
+    "label": "Work",
+    "address": "alejandro@example.com",
+    "send_short_email": false,
+    "send_html_email": false
+  },
+  {
+    "id": "PEC83HY",
+    "type": "sms_contact_method",
+    "summary": "Mobile",
+    "self": "https://api.pagerduty.com/users/PGJ36Z3/contact_methods/PEC83HY",
+    "html_url": null,
+    "label": "Mobile",
+    "address": "4155809923",
+    "country_code": 1,
+    "blacklisted": false,
+    "enabled": true
+  },
+  {
+    "id": "PBUSVMD",
+    "type": "phone_contact_method",
+    "summary": "Mobile",
+    "self": "https://api.pagerduty.com/users/P1RQ0Z6/contact_methods/PBUSVMD",
+    "html_url": null,
+    "label": "Mobile",
+    "address": "7076949626",
+    "country_code": 1,
+    "blacklisted": false
+  },
+  {
+    "id": "P4G3JKD",
+    "type": "push_notification_contact_method",
+    "summary": "Alex's iPhone",
+    "self": "https://api.pagerduty.com/users/P1RQ0Z6/contact_methods/P4G3JKD",
+    "html_url": null,
+    "label": "Alex's iPhone",
+    "address": "fcbaba06abe7533794b0dd7c3f4427b574772c01445e06bb5a006c33f14d95d0",
+    "device_type": "ios",
+    "sounds": [
+      {
+        "type": "alert_high_urgency",
+        "file": "default"
+      }
+    ],
+    "blacklisted": false,
+    "created_at": "2016-07-11T11:36:41-07:00"
+  }
+]

--- a/testdata/types/notification_rules.json
+++ b/testdata/types/notification_rules.json
@@ -1,0 +1,77 @@
+[
+  {
+    "id": "PM41X3T",
+    "type": "assignment_notification_rule_reference",
+    "summary": "0 minutes: channel P6YMJEE",
+    "self": "https://api.pagerduty.com/users/P5T36BU/notification_rules/PM41X3T",
+    "html_url": null
+  },
+  {
+    "id": "PNTRY7M",
+    "type": "assignment_notification_rule_reference",
+    "summary": "0 minutes: channel P6YMJEE",
+    "self": "https://api.pagerduty.com/users/P5T36BU/notification_rules/PNTRY7M",
+    "html_url": null
+  },
+  {
+    "id": "PW0WSB8",
+    "type": "assignment_notification_rule",
+    "summary": "0 minutes: channel PX11CYC",
+    "self": "https://api.pagerduty.com/users/PGJ36Z3/notification_rules/PW0WSB8",
+    "html_url": null,
+    "start_delay_in_minutes": 0,
+    "contact_method": {
+      "id": "PX11CYC",
+      "type": "email_contact_method",
+      "summary": "Default",
+      "self": "https://api.pagerduty.com/users/PGJ36Z3/contact_methods/PX11CYC",
+      "html_url": null,
+      "label": "Default",
+      "address": "acunningham@pagerduty.com",
+      "send_short_email": false,
+      "send_html_email": false
+    },
+    "urgency": "high"
+  },
+  {
+    "id": "PGITUFO",
+    "type": "assignment_notification_rule",
+    "summary": "0 minutes: channel PX11CYC",
+    "self": "https://api.pagerduty.com/users/PGJ36Z3/notification_rules/PGITUFO",
+    "html_url": null,
+    "start_delay_in_minutes": 0,
+    "contact_method": {
+      "id": "PX11CYC",
+      "type": "email_contact_method",
+      "summary": "Default",
+      "self": "https://api.pagerduty.com/users/PGJ36Z3/contact_methods/PX11CYC",
+      "html_url": null,
+      "label": "Default",
+      "address": "acunningham@pagerduty.com",
+      "send_short_email": false,
+      "send_html_email": false
+    },
+    "urgency": "low"
+  },
+  {
+    "id": "PEY06R9",
+    "type": "assignment_notification_rule",
+    "summary": "0 minutes: channel PEC83HY",
+    "self": "https://api.pagerduty.com/users/PGJ36Z3/notification_rules/PEY06R9",
+    "html_url": null,
+    "start_delay_in_minutes": 0,
+    "contact_method": {
+      "id": "PEC83HY",
+      "type": "sms_contact_method",
+      "summary": "Mobile",
+      "self": "https://api.pagerduty.com/users/PGJ36Z3/contact_methods/PEC83HY",
+      "html_url": null,
+      "label": "Mobile",
+      "address": "4155809923",
+      "country_code": 1,
+      "blacklisted": false,
+      "enabled": true
+    },
+    "urgency": "high"
+  }
+]

--- a/testdata/types/teams.json
+++ b/testdata/types/teams.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "PRJ4D5C",
+    "type": "team_reference",
+    "summary": "ops",
+    "self": "https://api.pagerduty.com/teams/PRJ4D5C",
+    "html_url": "https://webdemo.pagerduty.com/teams/PRJ4D5C"
+  },
+  {
+    "id": "P7W0ZIU",
+    "name": "Monitoring Tools Team",
+    "description": null,
+    "type": "team",
+    "summary": "Monitoring Tools Team",
+    "self": "https://api.pagerduty.com/teams/P7W0ZIU",
+    "html_url": "https://webdemo.pagerduty.com/teams/P7W0ZIU"
+  }
+]

--- a/testdata/types/users.json
+++ b/testdata/types/users.json
@@ -1,0 +1,51 @@
+[
+  {
+    "id": "PRMXSSO",
+    "type": "user_reference",
+    "summary": "Benedict Cumberbatch",
+    "self": "https://api.pagerduty.com/users/PRMXSSO",
+    "html_url": "https://webdemo.pagerduty.com/users/PRMXSSO"
+  },
+  {
+    "name": "abhijit@pagerduty.com",
+    "email": "abhijit@pagerduty.com",
+    "time_zone": "America/Los_Angeles",
+    "color": "olivedrab",
+    "avatar_url": "https://secure.gravatar.com/avatar/267299c8432bf9ab044472009c89a674.png?d=mm&r=PG",
+    "role": "user",
+    "description": null,
+    "invitation_sent": false,
+    "contact_methods": [
+      {
+        "id": "P6YMJEE",
+        "type": "email_contact_method_reference",
+        "summary": "Default",
+        "self": "https://api.pagerduty.com/users/P5T36BU/contact_methods/P6YMJEE",
+        "html_url": null
+      }
+    ],
+    "notification_rules": [
+      {
+        "id": "PM41X3T",
+        "type": "assignment_notification_rule_reference",
+        "summary": "0 minutes: channel P6YMJEE",
+        "self": "https://api.pagerduty.com/users/P5T36BU/notification_rules/PM41X3T",
+        "html_url": null
+      },
+      {
+        "id": "PNTRY7M",
+        "type": "assignment_notification_rule_reference",
+        "summary": "0 minutes: channel P6YMJEE",
+        "self": "https://api.pagerduty.com/users/P5T36BU/notification_rules/PNTRY7M",
+        "html_url": null
+      }
+    ],
+    "job_title": null,
+    "teams": [],
+    "id": "P5T36BU",
+    "type": "user",
+    "summary": "abhijit@pagerduty.com",
+    "self": "https://api.pagerduty.com/users/P5T36BU",
+    "html_url": "https://webdemo.pagerduty.com/users/P5T36BU"
+  }
+]


### PR DESCRIPTION
This still needs a bit of work. I have some panics and expects thrown
around that needs cleanup for sure. The main goal here was to get
round-trippable list of User objects and all dependencies.

 * Setup build scaffolding for serde
 * Add Ser/De and testdata for the following types:
   - Abilities
   - ContactMethods
   - NotificationRules
   - Teams
   - Users