### PR TITLE
Cleanup poor error handling

### DIFF
--- a/src/types/contact_methods.in.rs
+++ b/src/types/contact_methods.in.rs
@@ -1,5 +1,6 @@
 use serde::de::{Deserialize, Deserializer};
 use serde::ser::{Serialize, Serializer};
+use serde::Error;
 
 use super::reference::Reference;
 
@@ -258,45 +259,141 @@ impl Deserialize for ContactMethod {
                 })
             },
             "email_contact_method" => {
+
+                let address = match union.address {
+                    Some(val) => val,
+                    None => return Err(D::Error::missing_field("address")),
+                };
+
+                let label = match union.label {
+                    Some(val) => val,
+                    None => return Err(D::Error::missing_field("label")),
+                };
+
+                let send_short_email = match union.send_short_email {
+                    Some(val) => val,
+                    None => return Err(D::Error::missing_field("send_short_email")),
+                };
+
+                let send_html_email = match union.send_html_email {
+                    Some(val) => val,
+                    None => return Err(D::Error::missing_field("send_html_email")),
+                };
+
                 Ok(ContactMethod::EmailContactMethod {
                     reference: reference,
-                    address: union.address.expect("address"),
-                    label: union.label.expect("label"),
-                    send_short_email: union.send_short_email.expect("send_short_email"),
-                    send_html_email: union.send_html_email.expect("send_html_email"),
+                    address: address,
+                    label: label,
+                    send_short_email: send_short_email,
+                    send_html_email: send_html_email,
                 })
             },
             "phone_contact_method" => {
+                let address = match union.address {
+                    Some(val) => val,
+                    None => return Err(D::Error::missing_field("address")),
+                };
+
+                let label = match union.label {
+                    Some(val) => val,
+                    None => return Err(D::Error::missing_field("label")),
+                };
+
+                let blacklisted = match union.blacklisted {
+                    Some(val) => val,
+                    None => return Err(D::Error::missing_field("blacklisted")),
+                };
+
+                let country_code = match union.country_code {
+                    Some(val) => val,
+                    None => return Err(D::Error::missing_field("country_code")),
+                };
+
                 Ok(ContactMethod::PhoneContactMethod {
                     reference: reference,
-                    address: union.address.expect("address"),
-                    label: union.label.expect("label"),
-                    blacklisted: union.blacklisted.expect("blacklisted"),
-                    country_code: union.country_code.expect("country_code"),
+                    address: address,
+                    label: label,
+                    blacklisted: blacklisted,
+                    country_code: country_code,
                 })
             },
             "sms_contact_method" => {
+                let address = match union.address {
+                    Some(val) => val,
+                    None => return Err(D::Error::missing_field("address")),
+                };
+
+                let label = match union.label {
+                    Some(val) => val,
+                    None => return Err(D::Error::missing_field("label")),
+                };
+
+                let blacklisted = match union.blacklisted {
+                    Some(val) => val,
+                    None => return Err(D::Error::missing_field("blacklisted")),
+                };
+
+                let country_code = match union.country_code {
+                    Some(val) => val,
+                    None => return Err(D::Error::missing_field("country_code")),
+                };
+
+                let enabled = match union.enabled {
+                    Some(val) => val,
+                    None => return Err(D::Error::missing_field("enabled")),
+                };
+
                 Ok(ContactMethod::SmsContactMethod {
                     reference: reference,
-                    address: union.address.expect("address"),
-                    label: union.label.expect("label"),
-                    blacklisted: union.blacklisted.expect("blacklisted"),
-                    country_code: union.country_code.expect("country_code"),
-                    enabled: union.enabled.expect("enabled"),
+                    address: address,
+                    label: label,
+                    blacklisted: blacklisted,
+                    country_code: country_code,
+                    enabled: enabled,
                 })
             },
             "push_notification_contact_method" => {
+                let address = match union.address {
+                    Some(val) => val,
+                    None => return Err(D::Error::missing_field("address")),
+                };
+
+                let label = match union.label {
+                    Some(val) => val,
+                    None => return Err(D::Error::missing_field("label")),
+                };
+
+                let blacklisted = match union.blacklisted {
+                    Some(val) => val,
+                    None => return Err(D::Error::missing_field("blacklisted")),
+                };
+
+                let created_at = match union.created_at {
+                    Some(val) => val,
+                    None => return Err(D::Error::missing_field("created_at")),
+                };
+
+                let device_type = match union.device_type {
+                    Some(val) => val,
+                    None => return Err(D::Error::missing_field("device_type")),
+                };
+
+                let sounds = match union.sounds {
+                    Some(val) => val,
+                    None => return Err(D::Error::missing_field("sounds")),
+                };
+
                 Ok(ContactMethod::PushNotificationContactMethod {
                     reference: reference,
-                    address: union.address.expect("address"),
-                    label: union.label.expect("label"),
-                    blacklisted: union.blacklisted.expect("blacklisted"),
-                    created_at: union.created_at.expect("created_at"),
-                    device_type: union.device_type.expect("device_type"),
-                    sounds: union.sounds.expect("sounds"),
+                    address: address,
+                    label: label,
+                    blacklisted: blacklisted,
+                    created_at: created_at,
+                    device_type: device_type,
+                    sounds: sounds,
                 })
             },
-            _ => panic!("fuuuuuuu"),
+            _ => Err(D::Error::invalid_value("type received was unexpected.")),
         }
     }
 }

--- a/src/types/notification_rules.in.rs
+++ b/src/types/notification_rules.in.rs
@@ -1,5 +1,6 @@
 use serde::de::{Deserialize, Deserializer};
 use serde::ser::{Serialize, Serializer};
+use serde::Error;
 
 use super::reference::Reference;
 use super::contact_methods::ContactMethod;
@@ -100,14 +101,30 @@ impl Deserialize for NotificationRule {
                 })
             },
             "assignment_notification_rule" => {
+
+                let start_delay_in_minutes = match union.start_delay_in_minutes {
+                    Some(val) => val,
+                    None => return Err(D::Error::missing_field("start_delay_in_minutes")),
+                };
+
+                let contact_method = match union.contact_method {
+                    Some(val) => val,
+                    None => return Err(D::Error::missing_field("contact_method")),
+                };
+
+                let urgency = match union.urgency {
+                    Some(val) => val,
+                    None => return Err(D::Error::missing_field("urgency")),
+                };
+
                 Ok(NotificationRule::NotificationRule {
                     reference: reference,
-                    start_delay_in_minutes: union.start_delay_in_minutes.expect("start_delay_in_minutes"),
-                    contact_method: union.contact_method.expect("contact_method"),
-                    urgency: union.urgency.expect("urgency"),
+                    start_delay_in_minutes: start_delay_in_minutes,
+                    contact_method: contact_method,
+                    urgency: urgency,
                 })
             },
-            _ => panic!("fuuuuuuu"),
+            _ => Err(D::Error::invalid_value("type received was unexpected.")),
         }
     }
 }

--- a/src/types/teams.in.rs
+++ b/src/types/teams.in.rs
@@ -1,5 +1,6 @@
 use serde::de::{Deserialize, Deserializer};
 use serde::ser::{Serialize, Serializer};
+use serde::Error;
 
 use super::reference::Reference;
 
@@ -89,13 +90,18 @@ impl Deserialize for Team {
                 })
             },
             "team" => {
+                let name = match union.name {
+                    Some(val) => val,
+                    None => return Err(D::Error::missing_field("name")),
+                };
+
                 Ok(Team::Team {
                     reference: reference,
-                    name: union.name.expect("name"),
+                    name: name,
                     description: union.description,
                 })
             },
-            _ => panic!("fuuuuuuu"),
+            _ => Err(D::Error::invalid_value("type received was unexpected.")),
         }
     }
 }

--- a/src/types/users.in.rs
+++ b/src/types/users.in.rs
@@ -1,5 +1,6 @@
 use serde::de::{Deserialize, Deserializer};
 use serde::ser::{Serialize, Serializer};
+use serde::Error;
 
 use super::reference::Reference;
 use super::contact_methods::ContactMethods;
@@ -172,23 +173,73 @@ impl Deserialize for User {
                 })
             },
             "user" => {
+                let avatar_url = match union.avatar_url {
+                    Some(val) => val,
+                    None => return Err(D::Error::missing_field("avatar_url")),
+                };
+
+                let color = match union.color {
+                    Some(val) => val,
+                    None => return Err(D::Error::missing_field("color")),
+                };
+
+                let contact_methods = match union.contact_methods {
+                    Some(val) => val,
+                    None => return Err(D::Error::missing_field("contact_methods")),
+                };
+
+                let email = match union.email {
+                    Some(val) => val,
+                    None => return Err(D::Error::missing_field("email")),
+                };
+
+                let invitation_sent = match union.invitation_sent {
+                    Some(val) => val,
+                    None => return Err(D::Error::missing_field("invitation_sent")),
+                };
+
+                let name = match union.name {
+                    Some(val) => val,
+                    None => return Err(D::Error::missing_field("name")),
+                };
+
+                let notification_rules = match union.notification_rules {
+                    Some(val) => val,
+                    None => return Err(D::Error::missing_field("notification_rules")),
+                };
+
+                let role = match union.role {
+                    Some(val) => val,
+                    None => return Err(D::Error::missing_field("role")),
+                };
+
+                let teams = match union.teams {
+                    Some(val) => val,
+                    None => return Err(D::Error::missing_field("teams")),
+                };
+
+                let time_zone = match union.time_zone {
+                    Some(val) => val,
+                    None => return Err(D::Error::missing_field("time_zone")),
+                };
+
                 Ok(User::User {
                     reference: reference,
-                    avatar_url: union.avatar_url.expect("avatar_url"),
-                    color: union.color.expect("color"),
-                    contact_methods: union.contact_methods.expect("contact_methods"),
+                    avatar_url: avatar_url,
+                    color: color,
+                    contact_methods: contact_methods,
                     description: union.description,
-                    email: union.email.expect("email"),
-                    invitation_sent: union.invitation_sent.expect("invitation_sent"),
+                    email: email,
+                    invitation_sent: invitation_sent,
                     job_title: union.job_title,
-                    name: union.name.expect("name"),
-                    notification_rules: union.notification_rules.expect("notification_rules"),
-                    role: union.role.expect("role"),
-                    teams: union.teams.expect("teams"),
-                    time_zone: union.time_zone.expect("time_zone"),
+                    name: name,
+                    notification_rules: notification_rules,
+                    role: role,
+                    teams: teams,
+                    time_zone: time_zone,
                 })
             },
-            _ => panic!("fuuuuuuu"),
+            _ => Err(D::Error::invalid_value("type received was unexpected.")),
         }
     }
 }


### PR DESCRIPTION
Removed uses of expect and panic! from the following resources:

 * ContactMethods
 * NotificationRules
 * Teams
 * Users